### PR TITLE
refactor: use use case for membership signup

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,7 +11,7 @@
     "start": "cross-env DOTENV_CONFIG_PATH=../../.env node -r dotenv/config ./node_modules/@nestjs/cli/bin/nest.js start",
     "start:dev": "cross-env DOTENV_CONFIG_PATH=../../.env node -r dotenv/config ./node_modules/@nestjs/cli/bin/nest.js start --watch",
     "start:dev:db": "cross-env DOTENV_CONFIG_PATH=../../.env PORT=3002 USE_DB_PRISMA=true node -r dotenv/config ./node_modules/@nestjs/cli/bin/nest.js start --watch",
-    "start:dev:mem": "cross-env DOTENV_CONFIG_PATH=../../.env PORT=3001 node -r dotenv/config ./node_modules/@nestjs/cli/bin/nest.js start --watch",
+    "start:dev:mem": "cross-env DOTENV_CONFIG_PATH=../../.env PORT=3001 ENABLE_FAKE_SIGNUP=true node -r dotenv/config ./node_modules/@nestjs/cli/bin/nest.js start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",

--- a/apps/api/src/modules/memberships/infrastructure/module.ts
+++ b/apps/api/src/modules/memberships/infrastructure/module.ts
@@ -10,13 +10,24 @@ import {
 } from '../application/tokens';
 import { SyncUserUseCase } from '../application/use_cases/syncUser';
 import { ClerkWebhookController } from '../presentation/controllers/clerkWebhook.controller';
+import { SignupController } from '../presentation/controllers/signup.controller';
 import { SvixWebhookVerifier } from './providers/svixWebhook';
-import { FakeSignupController } from '../presentation/controllers/signup.controller';
 
 export const PRISMA_CLIENT = 'PRISMA_CLIENT_MEMBERSHIPS';
 
+const controllers: any[] = [ClerkWebhookController, SignupController];
+
+if (process.env.ENABLE_FAKE_SIGNUP === 'true') {
+  // Lazy load to avoid bundling in production builds
+
+  const {
+    FakeSignupController,
+  } = require('../presentation/controllers/fakeSignup.controller');
+  controllers.push(FakeSignupController);
+}
+
 @Module({
-  controllers: [ClerkWebhookController, FakeSignupController],
+  controllers,
   providers: [
     {
       provide: PRISMA_CLIENT,

--- a/apps/api/src/modules/memberships/presentation/controllers/fakeSignup.controller.ts
+++ b/apps/api/src/modules/memberships/presentation/controllers/fakeSignup.controller.ts
@@ -1,0 +1,47 @@
+import { Body, Controller, HttpCode, Post } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+
+class FakeSignupDto {
+  email!: string;
+  firstName!: string;
+  lastName!: string;
+  phone?: string;
+  tenantName?: string;
+}
+
+@Controller('signup')
+export class FakeSignupController {
+  private static activated = new Set<string>();
+  // MVP: no persistence; return a fake auth token containing memberId
+  @Post('fake-checkout')
+  @HttpCode(200)
+  async fakeCheckout(@Body() body: any) {
+    const memberId = randomUUID();
+    const token = `fake.${memberId}`;
+    return {
+      ok: true,
+      memberId,
+      token,
+      // send the UI to a hosted-like payment step (mocked)
+      redirect: `/signup/payment?memberId=${memberId}`,
+    };
+  }
+
+  // Mock payment endpoint: activates the member as if Stripe webhook confirmed
+  @Post('mock-pay')
+  @HttpCode(200)
+  async mockPay(@Body() body: { memberId: string }) {
+    const memberId = body?.memberId ?? randomUUID();
+    FakeSignupController.activated.add(memberId);
+    return { ok: true, memberId, status: 'ACTIVE' };
+  }
+
+  // Optional: query membership status (optimistic UI → final state)
+  @Post('status')
+  @HttpCode(200)
+  async status(@Body() body: { memberId: string }) {
+    const memberId = body?.memberId;
+    const active = !!memberId && FakeSignupController.activated.has(memberId);
+    return { ok: true, memberId, status: active ? 'ACTIVE' : 'PENDING' };
+  }
+}

--- a/apps/api/src/modules/memberships/presentation/controllers/signup.controller.ts
+++ b/apps/api/src/modules/memberships/presentation/controllers/signup.controller.ts
@@ -1,47 +1,33 @@
-import { Body, Controller, HttpCode, Post } from '@nestjs/common';
-import { randomUUID } from 'crypto';
+import { Body, Controller, HttpCode, Inject, Post } from '@nestjs/common';
+import { SyncUserUseCase } from '../../application/use_cases/syncUser';
+import { SyncUserUseCaseToken } from '../../application/tokens';
 
-class FakeSignupDto {
+class SignupDto {
   email!: string;
-  firstName!: string;
-  lastName!: string;
+  firstName?: string;
+  lastName?: string;
   phone?: string;
-  tenantName?: string;
+  tenantName!: string;
 }
 
 @Controller('signup')
-export class FakeSignupController {
-  private static activated = new Set<string>();
-  // MVP: no persistence; return a fake auth token containing memberId
-  @Post('fake-checkout')
-  @HttpCode(200)
-  async fakeCheckout(@Body() body: any) {
-    const memberId = randomUUID();
-    const token = `fake.${memberId}`;
-    return {
-      ok: true,
-      memberId,
-      token,
-      // send the UI to a hosted-like payment step (mocked)
-      redirect: `/signup/payment?memberId=${memberId}`,
-    };
-  }
+export class SignupController {
+  constructor(
+    @Inject(SyncUserUseCaseToken) private readonly syncUser: SyncUserUseCase,
+  ) {}
 
-  // Mock payment endpoint: activates the member as if Stripe webhook confirmed
-  @Post('mock-pay')
+  @Post()
   @HttpCode(200)
-  async mockPay(@Body() body: { memberId: string }) {
-    const memberId = body?.memberId ?? randomUUID();
-    FakeSignupController.activated.add(memberId);
-    return { ok: true, memberId, status: 'ACTIVE' };
-  }
-
-  // Optional: query membership status (optimistic UI → final state)
-  @Post('status')
-  @HttpCode(200)
-  async status(@Body() body: { memberId: string }) {
-    const memberId = body?.memberId;
-    const active = !!memberId && FakeSignupController.activated.has(memberId);
-    return { ok: true, memberId, status: active ? 'ACTIVE' : 'PENDING' };
+  async signup(@Body() body: SignupDto) {
+    const result = await this.syncUser.execute({
+      email: body.email,
+      firstName: body.firstName,
+      lastName: body.lastName,
+      phone: body.phone,
+      tenantName: body.tenantName,
+      role: 'member',
+      status: 'PENDING',
+    });
+    return result;
   }
 }


### PR DESCRIPTION
## Summary
- replace in-memory signup flow with SyncUserUseCase
- move mock signup endpoints to a separate FakeSignupController behind `ENABLE_FAKE_SIGNUP`
- wire controllers conditionally and expose flag in dev script

## Testing
- `pnpm --filter api test` *(fails: @prisma/client did not initialize yet)*
- `pnpm prisma generate` *(fails: 403 fetching prisma engine)*
- `pnpm --filter api lint` *(fails: 201 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f0113760832cb4a0c655d94a4af1