### PR TITLE
refactor: abstract scheduling cross-cutting services

### DIFF
--- a/apps/api/src/modules/scheduling/application/tokens.ts
+++ b/apps/api/src/modules/scheduling/application/tokens.ts
@@ -1,6 +1,9 @@
 export const ISessionRepoToken = 'Scheduling.ISessionRepo';
 export const IBookingRepoToken = 'Scheduling.IBookingRepo';
 export const IWaitlistRepoToken = 'Scheduling.IWaitlistRepo';
+export const IClockToken = 'Scheduling.IClock';
+export const IIdProviderToken = 'Scheduling.IIdProvider';
+export const IEventBusToken = 'Scheduling.IEventBus';
 
 export const ListSessionsUseCaseToken = 'Scheduling.ListSessionsUseCase';
 export const CreateSessionUseCaseToken = 'Scheduling.CreateSessionUseCase';

--- a/apps/api/src/modules/scheduling/infrastructure/module.ts
+++ b/apps/api/src/modules/scheduling/infrastructure/module.ts
@@ -1,5 +1,15 @@
 import { Module } from '@nestjs/common';
-import { ISessionRepoToken, IBookingRepoToken, IWaitlistRepoToken, ListSessionsUseCaseToken, CreateSessionUseCaseToken, RegisterForSessionUseCaseToken } from '../application/tokens';
+import {
+  ISessionRepoToken,
+  IBookingRepoToken,
+  IWaitlistRepoToken,
+  ListSessionsUseCaseToken,
+  CreateSessionUseCaseToken,
+  RegisterForSessionUseCaseToken,
+  IClockToken,
+  IIdProviderToken,
+  IEventBusToken,
+} from '../application/tokens';
 import { InMemorySessionRepo, seedSessions } from './adapters/inMemory/sessionRepo';
 import { PrismaSessionRepo } from './adapters/prisma/sessionRepo';
 import { getPrisma } from './providers/db/prismaClient';
@@ -11,6 +21,12 @@ import { RegisterForSessionUseCase } from '../application/use_cases/registerForS
 import { SystemClock } from './providers/clock/systemClock';
 import { UuidProvider } from './providers/id/uuidProvider';
 import { InMemoryEventBus } from './providers/events/inMemoryEventBus';
+import { Clock } from '../application/ports/Clock';
+import { IdProvider } from '../application/ports/IdProvider';
+import { EventBus } from '../application/ports/EventBus';
+import { SessionRepo } from '../application/ports/SessionRepo';
+import { IBookingRepo } from '../application/ports/BookingRepo';
+import { IWaitlistRepo } from '../application/ports/WaitlistRepo';
 
 @Module({
   providers: [
@@ -26,32 +42,32 @@ import { InMemoryEventBus } from './providers/events/inMemoryEventBus';
     { provide: IWaitlistRepoToken, useClass: InMemoryWaitlistRepo },
 
     // Cross-cutting providers
-    { provide: SystemClock, useClass: SystemClock },
-    { provide: UuidProvider, useClass: UuidProvider },
-    { provide: InMemoryEventBus, useClass: InMemoryEventBus },
+    { provide: IClockToken, useClass: SystemClock },
+    { provide: IIdProviderToken, useClass: UuidProvider },
+    { provide: IEventBusToken, useClass: InMemoryEventBus },
 
     // Use cases
     {
       provide: ListSessionsUseCaseToken,
-      useFactory: (sessionsRepo: any) => new ListSessionsUseCase(sessionsRepo),
+      useFactory: (sessionsRepo: SessionRepo) => new ListSessionsUseCase(sessionsRepo),
       inject: [ISessionRepoToken],
     },
     {
       provide: CreateSessionUseCaseToken,
-      useFactory: (sessionsRepo: any, clock: SystemClock, ids: UuidProvider, events: InMemoryEventBus) =>
+      useFactory: (sessionsRepo: SessionRepo, clock: Clock, ids: IdProvider, events: EventBus) =>
         new CreateSessionUseCase(sessionsRepo, clock, ids, events),
-      inject: [ISessionRepoToken, SystemClock, UuidProvider, InMemoryEventBus],
+      inject: [ISessionRepoToken, IClockToken, IIdProviderToken, IEventBusToken],
     },
     {
       provide: RegisterForSessionUseCaseToken,
       useFactory: (
-        sessionsRepo: any,
-        bookingRepo: any,
-        waitlistRepo: any,
-        clock: SystemClock,
-        ids: UuidProvider,
+        sessionsRepo: SessionRepo,
+        bookingRepo: IBookingRepo,
+        waitlistRepo: IWaitlistRepo,
+        clock: Clock,
+        ids: IdProvider,
       ) => new RegisterForSessionUseCase(sessionsRepo, bookingRepo, waitlistRepo, clock, ids),
-      inject: [ISessionRepoToken, IBookingRepoToken, IWaitlistRepoToken, SystemClock, UuidProvider],
+      inject: [ISessionRepoToken, IBookingRepoToken, IWaitlistRepoToken, IClockToken, IIdProviderToken],
     },
   ],
   exports: [

--- a/apps/api/src/modules/scheduling/infrastructure/providers/events/inMemoryEventBus.ts
+++ b/apps/api/src/modules/scheduling/infrastructure/providers/events/inMemoryEventBus.ts
@@ -1,6 +1,6 @@
-export type DomainEvent = { type: string; payload: any; occurredAt: string };
+import { EventBus, DomainEvent } from '../../../application/ports/EventBus';
 
-export class InMemoryEventBus {
+export class InMemoryEventBus implements EventBus {
   private events: DomainEvent[] = [];
 
   emit(event: DomainEvent) {


### PR DESCRIPTION
## Summary
- add DI tokens for clock, id provider, and event bus
- wire use cases through new tokens and interface types
- implement InMemoryEventBus via EventBus interface

## Testing
- `pnpm --filter api test` *(fails: @prisma/client did not initialize yet)*
- `pnpm --filter api exec prisma generate` *(fails: 403 fetching prisma engine)*
- `pnpm --filter api build`

------
https://chatgpt.com/codex/tasks/task_e_68a7f01333b0832c994e0a209e151584