### PR TITLE
Refactor scheduling entities with value objects

### DIFF
--- a/apps/api/src/modules/scheduling/application/ports/BookingRepo.ts
+++ b/apps/api/src/modules/scheduling/application/ports/BookingRepo.ts
@@ -1,12 +1,9 @@
-export interface Booking {
-  id: string;
-  sessionId: string;
-  memberId: string;
-  createdAt: Date;
-}
+import { BookingEntity } from '../../domain/entities/Booking';
+import { SessionId } from '../../domain/value_objects/SessionId';
+import { MemberId } from '../../domain/value_objects/MemberId';
 
 export interface IBookingRepo {
-  create(booking: Booking): Promise<void>;
-  countBySession(sessionId: string): Promise<number>;
-  findByMemberSession(memberId: string, sessionId: string): Promise<Booking | null>;
+  create(booking: BookingEntity): Promise<void>;
+  countBySession(sessionId: SessionId): Promise<number>;
+  findByMemberSession(memberId: MemberId, sessionId: SessionId): Promise<BookingEntity | null>;
 }

--- a/apps/api/src/modules/scheduling/application/ports/WaitlistRepo.ts
+++ b/apps/api/src/modules/scheduling/application/ports/WaitlistRepo.ts
@@ -1,13 +1,9 @@
-export interface WaitlistEntry {
-  id: string;
-  sessionId: string;
-  memberId: string;
-  position: number;
-  createdAt: Date;
-}
+import { WaitlistEntryEntity } from '../../domain/entities/WaitlistEntry';
+import { SessionId } from '../../domain/value_objects/SessionId';
+import { MemberId } from '../../domain/value_objects/MemberId';
 
 export interface IWaitlistRepo {
-  enqueue(entry: WaitlistEntry): Promise<void>;
-  countBySession(sessionId: string): Promise<number>;
-  findByMemberSession(memberId: string, sessionId: string): Promise<WaitlistEntry | null>;
+  enqueue(entry: WaitlistEntryEntity): Promise<void>;
+  countBySession(sessionId: SessionId): Promise<number>;
+  findByMemberSession(memberId: MemberId, sessionId: SessionId): Promise<WaitlistEntryEntity | null>;
 }

--- a/apps/api/src/modules/scheduling/application/use_cases/registerForSession.ts
+++ b/apps/api/src/modules/scheduling/application/use_cases/registerForSession.ts
@@ -1,12 +1,18 @@
 import { SessionRepo } from '../ports/SessionRepo';
-import { IBookingRepo, Booking } from '../ports/BookingRepo';
-import { IWaitlistRepo, WaitlistEntry } from '../ports/WaitlistRepo';
+import { IBookingRepo } from '../ports/BookingRepo';
+import { IWaitlistRepo } from '../ports/WaitlistRepo';
 import type { Result } from '../common/result';
 import { ok, err } from '../common/result';
 import { Clock } from '../ports/Clock';
 import { IdProvider } from '../ports/IdProvider';
+import { BookingEntity } from '../../domain/entities/Booking';
+import { WaitlistEntryEntity } from '../../domain/entities/WaitlistEntry';
+import { BookingId } from '../../domain/value_objects/BookingId';
+import { WaitlistEntryId } from '../../domain/value_objects/WaitlistEntryId';
+import { SessionId } from '../../domain/value_objects/SessionId';
+import { MemberId } from '../../domain/value_objects/MemberId';
 
-export type RegisterOk = { kind: 'BOOKED'; booking: Booking } | { kind: 'WAITLISTED'; entry: WaitlistEntry };
+export type RegisterOk = { kind: 'BOOKED'; booking: BookingEntity } | { kind: 'WAITLISTED'; entry: WaitlistEntryEntity };
 export type RegisterErr =
   | { kind: 'SessionNotFound' }
   | { kind: 'AlreadyRegistered' };
@@ -20,8 +26,11 @@ export class RegisterForSessionUseCase {
     private readonly ids: IdProvider,
   ) {}
 
-  async execute(memberId: string, sessionId: string): Promise<Result<RegisterOk, RegisterErr>> {
-    const session = await this.sessions.getById(sessionId);
+  async execute(memberIdRaw: string, sessionIdRaw: string): Promise<Result<RegisterOk, RegisterErr>> {
+    const sessionId = SessionId.create(sessionIdRaw);
+    const memberId = MemberId.create(memberIdRaw);
+
+    const session = await this.sessions.getById(sessionId.value);
     if (!session) return err({ kind: 'SessionNotFound' });
 
     const existing = await this.bookings.findByMemberSession(memberId, sessionId);
@@ -29,24 +38,24 @@ export class RegisterForSessionUseCase {
 
     const count = await this.bookings.countBySession(sessionId);
     if (count < session.maxCapacity) {
-      const booking: Booking = {
-        id: this.ids.next(),
+      const booking = BookingEntity.create({
+        id: BookingId.create(this.ids.next()),
         sessionId,
         memberId,
         createdAt: this.clock.now(),
-      };
+      });
       await this.bookings.create(booking);
       return ok({ kind: 'BOOKED', booking });
     }
 
     const position = (await this.waitlist.countBySession(sessionId)) + 1;
-    const entry: WaitlistEntry = {
-      id: this.ids.next(),
+    const entry = WaitlistEntryEntity.create({
+      id: WaitlistEntryId.create(this.ids.next()),
       sessionId,
       memberId,
       position,
       createdAt: this.clock.now(),
-    };
+    });
     await this.waitlist.enqueue(entry);
     return ok({ kind: 'WAITLISTED', entry });
   }

--- a/apps/api/src/modules/scheduling/domain/entities/Booking.ts
+++ b/apps/api/src/modules/scheduling/domain/entities/Booking.ts
@@ -1,8 +1,23 @@
+import { BookingId } from '../value_objects/BookingId';
+import { SessionId } from '../value_objects/SessionId';
+import { MemberId } from '../value_objects/MemberId';
+
 export class BookingEntity {
-  constructor(
-    public readonly id: string,
-    public readonly sessionId: string,
-    public readonly memberId: string,
+  private constructor(
+    public readonly id: BookingId,
+    public readonly sessionId: SessionId,
+    public readonly memberId: MemberId,
     public readonly createdAt: Date,
   ) {}
+
+  static create(params: {
+    id: BookingId;
+    sessionId: SessionId;
+    memberId: MemberId;
+    createdAt: Date;
+  }): BookingEntity {
+    const { id, sessionId, memberId, createdAt } = params;
+    if (!createdAt) throw new Error('createdAt is required');
+    return new BookingEntity(id, sessionId, memberId, createdAt);
+  }
 }

--- a/apps/api/src/modules/scheduling/domain/entities/WaitlistEntry.ts
+++ b/apps/api/src/modules/scheduling/domain/entities/WaitlistEntry.ts
@@ -1,9 +1,28 @@
+import { WaitlistEntryId } from '../value_objects/WaitlistEntryId';
+import { SessionId } from '../value_objects/SessionId';
+import { MemberId } from '../value_objects/MemberId';
+
 export class WaitlistEntryEntity {
-  constructor(
-    public readonly id: string,
-    public readonly sessionId: string,
-    public readonly memberId: string,
+  private constructor(
+    public readonly id: WaitlistEntryId,
+    public readonly sessionId: SessionId,
+    public readonly memberId: MemberId,
     public readonly position: number,
     public readonly createdAt: Date,
   ) {}
+
+  static create(params: {
+    id: WaitlistEntryId;
+    sessionId: SessionId;
+    memberId: MemberId;
+    position: number;
+    createdAt: Date;
+  }): WaitlistEntryEntity {
+    const { id, sessionId, memberId, position, createdAt } = params;
+    if (!Number.isInteger(position) || position <= 0) {
+      throw new Error('position must be a positive integer');
+    }
+    if (!createdAt) throw new Error('createdAt is required');
+    return new WaitlistEntryEntity(id, sessionId, memberId, position, createdAt);
+  }
 }

--- a/apps/api/src/modules/scheduling/domain/value_objects/BookingId.ts
+++ b/apps/api/src/modules/scheduling/domain/value_objects/BookingId.ts
@@ -1,0 +1,12 @@
+export class BookingId {
+  private constructor(public readonly value: string) {}
+
+  static create(raw: string): BookingId {
+    if (!raw || raw.trim().length === 0) throw new Error('BookingId cannot be empty');
+    return new BookingId(raw);
+  }
+
+  equals(other: BookingId): boolean {
+    return this.value === other.value;
+  }
+}

--- a/apps/api/src/modules/scheduling/domain/value_objects/MemberId.ts
+++ b/apps/api/src/modules/scheduling/domain/value_objects/MemberId.ts
@@ -1,0 +1,12 @@
+export class MemberId {
+  private constructor(public readonly value: string) {}
+
+  static create(raw: string): MemberId {
+    if (!raw || raw.trim().length === 0) throw new Error('MemberId cannot be empty');
+    return new MemberId(raw);
+  }
+
+  equals(other: MemberId): boolean {
+    return this.value === other.value;
+  }
+}

--- a/apps/api/src/modules/scheduling/domain/value_objects/SessionId.ts
+++ b/apps/api/src/modules/scheduling/domain/value_objects/SessionId.ts
@@ -1,0 +1,12 @@
+export class SessionId {
+  private constructor(public readonly value: string) {}
+
+  static create(raw: string): SessionId {
+    if (!raw || raw.trim().length === 0) throw new Error('SessionId cannot be empty');
+    return new SessionId(raw);
+  }
+
+  equals(other: SessionId): boolean {
+    return this.value === other.value;
+  }
+}

--- a/apps/api/src/modules/scheduling/domain/value_objects/WaitlistEntryId.ts
+++ b/apps/api/src/modules/scheduling/domain/value_objects/WaitlistEntryId.ts
@@ -1,0 +1,12 @@
+export class WaitlistEntryId {
+  private constructor(public readonly value: string) {}
+
+  static create(raw: string): WaitlistEntryId {
+    if (!raw || raw.trim().length === 0) throw new Error('WaitlistEntryId cannot be empty');
+    return new WaitlistEntryId(raw);
+  }
+
+  equals(other: WaitlistEntryId): boolean {
+    return this.value === other.value;
+  }
+}

--- a/apps/api/src/modules/scheduling/infrastructure/adapters/inMemory/bookingRepo.ts
+++ b/apps/api/src/modules/scheduling/infrastructure/adapters/inMemory/bookingRepo.ts
@@ -1,16 +1,19 @@
-import { IBookingRepo, Booking } from '../../../application/ports/BookingRepo';
+import { IBookingRepo } from '../../../application/ports/BookingRepo';
+import { BookingEntity } from '../../../domain/entities/Booking';
+import { SessionId } from '../../../domain/value_objects/SessionId';
+import { MemberId } from '../../../domain/value_objects/MemberId';
 
 export class InMemoryBookingRepo implements IBookingRepo {
-  private items: Booking[] = [];
+  private items: BookingEntity[] = [];
 
-  async create(booking: Booking): Promise<void> {
+  async create(booking: BookingEntity): Promise<void> {
     this.items.push(booking);
   }
-  async countBySession(sessionId: string): Promise<number> {
-    return this.items.filter(b => b.sessionId === sessionId).length;
+  async countBySession(sessionId: SessionId): Promise<number> {
+    return this.items.filter(b => b.sessionId.value === sessionId.value).length;
   }
-  async findByMemberSession(memberId: string, sessionId: string): Promise<Booking | null> {
-    return this.items.find(b => b.memberId === memberId && b.sessionId === sessionId) ?? null;
+  async findByMemberSession(memberId: MemberId, sessionId: SessionId): Promise<BookingEntity | null> {
+    return this.items.find(b => b.memberId.value === memberId.value && b.sessionId.value === sessionId.value) ?? null;
   }
   clear() { this.items = []; }
 }

--- a/apps/api/src/modules/scheduling/infrastructure/adapters/inMemory/waitlistRepo.ts
+++ b/apps/api/src/modules/scheduling/infrastructure/adapters/inMemory/waitlistRepo.ts
@@ -1,16 +1,19 @@
-import { IWaitlistRepo, WaitlistEntry } from '../../../application/ports/WaitlistRepo';
+import { IWaitlistRepo } from '../../../application/ports/WaitlistRepo';
+import { WaitlistEntryEntity } from '../../../domain/entities/WaitlistEntry';
+import { SessionId } from '../../../domain/value_objects/SessionId';
+import { MemberId } from '../../../domain/value_objects/MemberId';
 
 export class InMemoryWaitlistRepo implements IWaitlistRepo {
-  private items: WaitlistEntry[] = [];
+  private items: WaitlistEntryEntity[] = [];
 
-  async enqueue(entry: WaitlistEntry): Promise<void> {
+  async enqueue(entry: WaitlistEntryEntity): Promise<void> {
     this.items.push(entry);
   }
-  async countBySession(sessionId: string): Promise<number> {
-    return this.items.filter(e => e.sessionId === sessionId).length;
+  async countBySession(sessionId: SessionId): Promise<number> {
+    return this.items.filter(e => e.sessionId.value === sessionId.value).length;
   }
-  async findByMemberSession(memberId: string, sessionId: string): Promise<WaitlistEntry | null> {
-    return this.items.find(e => e.memberId === memberId && e.sessionId === sessionId) ?? null;
+  async findByMemberSession(memberId: MemberId, sessionId: SessionId): Promise<WaitlistEntryEntity | null> {
+    return this.items.find(e => e.memberId.value === memberId.value && e.sessionId.value === sessionId.value) ?? null;
   }
   clear() { this.items = []; }
 }

--- a/apps/api/src/modules/scheduling/presentation/controllers/sessions.controller.ts
+++ b/apps/api/src/modules/scheduling/presentation/controllers/sessions.controller.ts
@@ -110,7 +110,7 @@ export class SchedulingSessionsController {
     if (result.ok) {
       const value = result.value;
       if (value.kind === 'BOOKED') {
-        return { status: 'BOOKED', bookingId: value.booking.id };
+        return { status: 'BOOKED', bookingId: value.booking.id.value };
       }
       return { status: 'WAITLISTED', position: value.entry.position };
     }


### PR DESCRIPTION
## Summary
- Introduce BookingId, WaitlistEntryId, SessionId and MemberId value objects
- Add validation factories and private constructors to BookingEntity and WaitlistEntryEntity
- Update register for session flow and repositories to use new value objects

## Testing
- `DATABASE_URL= pnpm --filter api test` *(fails: @prisma/client did not initialize yet)*
- `pnpm --filter api exec prisma generate` *(fails: 403 fetching prisma engine)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f01757a4832cb25f9296b4b87d14